### PR TITLE
Add curl to runtime packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,13 @@ RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
 	bzip2 \
-	curl \
 	gcc \
 	make \
 	tar \
 	wget && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
+    curl \
 	inotify-tools \
 	jq \
 	perl \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -11,13 +11,13 @@ RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
 	bzip2 \
-	curl \
 	gcc \
 	make \
 	tar \
 	wget && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
+    curl \
 	inotify-tools \
 	jq \
 	perl \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -11,13 +11,13 @@ RUN \
  echo "**** install build packages ****" && \
  apk add --no-cache --virtual=build-dependencies \
 	bzip2 \
-	curl \
 	gcc \
 	make \
 	tar \
 	wget && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
+    curl \
 	inotify-tools \
 	jq \
 	perl \


### PR DESCRIPTION
Following a report on Discord from nicedevil

I'm struggling with the ddclient docker container because it doesn't has curl installed and my dyndns host needs it to update everything, what should I do to get it into your image? :heart:
here is an example what I have to enter to get it to run:
```
protocol=dyndns2
use=if, if=eth0
ssl=yes
use=cmd, cmd='curl https://checkipv4.dedyn.io/'
server=update.dedyn.io
login=XXXX.dedyn.io
password='XXXX'
XXXX.dedyn.io
```
That is what the log says to me:
```
Can't exec "curl": No such file or directory at /usr/bin/ddclient line 2175.
WARNING:  found neither ipv4 nor ipv6 address
```
Confirmed a fix with `docker exec -it ddclient apk add curl`