### PR TITLE
Update configuration script with better permissions behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **06.02.19:** - Fix permissions.
 * **19.12.19:** - Rebasing to alpine 3.11.
 * **28.06.19:** - Rebasing to alpine 3.10.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,6 +46,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "06.02.19:", desc: "Fix permissions." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -2,24 +2,24 @@
 
 # make our folders
 mkdir -p \
-        /var/cache/ddclient \
-        /var/run/ddclient
+    /var/cache/ddclient \
+    /var/run/ddclient
 
 # copy default config if not present in /config
 [[ ! -e /config/ddclient.conf ]] && \
-        cp /defaults/ddclient.conf /config
+    cp /defaults/ddclient.conf /config
 
 # copy config from /config to root
 cp /config/ddclient.conf /ddclient.conf
 
 # permissions
 chown -R abc:abc \
-        /config \
-        /var/cache/ddclient \
-        /var/run/ddclient \
-        /ddclient.conf
+    /config \
+    /var/cache/ddclient \
+    /var/run/ddclient \
+    /ddclient.conf
 
 chmod 700 /config
 chmod 600 \
-	/config/* \
-	/ddclient.conf
+    /config/* \
+    /ddclient.conf

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,21 +1,25 @@
 #!/usr/bin/with-contenv bash
 
-# make our folders
+# make our folders
 mkdir -p \
-	/var/cache/ddclient \
-	/var/run/ddclient
+        /var/cache/ddclient \
+        /var/run/ddclient
 
 # copy default config if not present in /config
 [[ ! -e /config/ddclient.conf ]] && \
-	cp /defaults/ddclient.conf /config
+        cp /defaults/ddclient.conf /config
 
 # copy config from /config to root
 cp /config/ddclient.conf /ddclient.conf
 
-# permissions
+# permissions
 chown -R abc:abc \
-	/config \
-	/var/cache/ddclient \
-	/var/run/ddclient
-chmod -R 600 \
-	/config
+        /config \
+        /var/cache/ddclient \
+        /var/run/ddclient \
+        /ddclient.conf
+
+chmod 700 /config
+chmod 600 \
+	/config/* \
+	/ddclient.conf


### PR DESCRIPTION
fixes #30

Updated the permission setting script to:
- chmod/chown the eventual config file that gets run, killing a warning that kept appearing in the logs
- chmod the config directory with +x, so it remains accessible
- chmod config files to 600