### PR TITLE
Improve restarting ddclient after config modified

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,6 +46,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "01.24.21:", desc: "Improve support for automatically restarting ddclient when config modified." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "08.02.20:", desc: "Ingest from Github." }
   - { date: "06.02.19:", desc: "Fix permissions." }

--- a/root/etc/services.d/inotify_modify/run
+++ b/root/etc/services.d/inotify_modify/run
@@ -1,10 +1,15 @@
 #!/usr/bin/with-contenv bash
 
 # starting inotify to watch /config/ddclient.conf and restart ddclient if changed.
-while inotifywait -e modify /config/ddclient.conf; do
-	cp /config/ddclient.conf /ddclient.conf
-	chown abc:abc /ddclient.conf
-	chmod 600 /ddclient.conf
-	s6-svc -h /var/run/s6/services/ddclient
-	echo "ddclient has been restarted"
-done
+inotifywait -mq -e close_write,moved_to --format "%e %f" /config/ |
+        while read events filename; do
+                if [ "$filename" != "ddclient.conf" ]; then
+                        continue
+                fi
+
+                cp /config/ddclient.conf /ddclient.conf
+                chown abc:abc /ddclient.conf
+                chmod 600 /ddclient.conf
+                s6-svc -h /var/run/s6/services/ddclient
+                echo "ddclient has been restarted"
+        done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ddclient/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Ddclient wasn't getting restarted correctly when the config file was edited with some editors (vim, in my case).  Per the references below, this is because of the way that vim persists its changes to files.  The fix is to monitor the entire directory for changes rather than the file directly.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Fixes #41.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test cases:
- Editing the file in vi, vim, and nano (all result in a "close_write" event)
- Deleting the file and `cp`-ing it back (results in a "close_write" event)
- Deleting the file and `mv`-ing it back (results in a "moved_to" event)

I couldn't find a case where the "modify" event was necessary.  Including it would cause duplicate events to be fired in short succession before the "close_write" when the file was written by vim and nano.  

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
- [Using inotifywait along with vim](https://unix.stackexchange.com/questions/188873/using-inotifywait-along-with-vim)
- [Vim not firing inotify events when writing file](https://vi.stackexchange.com/questions/25030/vim-not-firing-inotify-events-when-writing-file)