### PR TITLE
Add 'sample-get-ip-from-fritzbox' (closes #37)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,8 @@ RUN \
  /tmp/ddclient.tar.gz -C \
 	/tmp/ddclient --strip-components=1 && \
  install -Dm755 /tmp/ddclient/ddclient /usr/bin/ && \
+ mkdir -p /etc/ddclient/ && \
+ cp /tmp/ddclient/sample-get-ip-from-fritzbox /etc/ddclient/get-ip-from-fritzbox && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -45,6 +45,8 @@ RUN \
  /tmp/ddclient.tar.gz -C \
 	/tmp/ddclient --strip-components=1 && \
  install -Dm755 /tmp/ddclient/ddclient /usr/bin/ && \
+ mkdir -p /etc/ddclient/ && \
+ cp /tmp/ddclient/sample-get-ip-from-fritzbox /etc/ddclient/get-ip-from-fritzbox && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,6 +45,8 @@ RUN \
  /tmp/ddclient.tar.gz -C \
 	/tmp/ddclient --strip-components=1 && \
  install -Dm755 /tmp/ddclient/ddclient /usr/bin/ && \
+ mkdir -p /etc/ddclient/ && \
+ cp /tmp/ddclient/sample-get-ip-from-fritzbox /etc/ddclient/get-ip-from-fritzbox && \
  echo "**** cleanup ****" && \
  apk del --purge \
 	build-dependencies && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -42,7 +42,13 @@ optional_block_1: false
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  Edit the ddclient.conf file found in your /config volume. This config file has many providers to choose from and you basically just have to uncomment your provider and add username/password where requested. If you modify ddclient.conf, ddclient will automaticcaly restart and read the config.
+  Edit the `ddclient.conf` file found in your `/config` volume (also see official [ddclient documentation](https://ddclient.net)). This config file has many providers to choose from and you basically just have to uncomment your provider and add username/password where requested. If you modify ddclient.conf, ddclient will automaticcaly restart and read the config.
+  
+  ### Get dynamic IP from Fritz.Box
+  If ddclient shall fetch the dynamic (public) IP-address from a fritz.box (AVM) add the following line to `/config/ddclient.conf`:
+  ````
+  use=cmd, cmd=/etc/ddclient/get-ip-from-fritzbox
+  ````
 
 # changelog
 changelogs:

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -46,6 +46,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "15.05.21:", desc: "Distribute script 'sample-get-ip-from-fritzbox' from ddclient repo" }  
   - { date: "08.03.21:", desc: "Added bind-tools to provide nsupdate" }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "08.02.20:", desc: "Ingest from Github." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ddclient/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
This PR adds the `sample-get-ip-from-fritzbox` script from the original  [ddclient repo](https://github.com/ddclient/ddclient) and copies it to `/etc/ddclient/get-ip-from-fritzbox` as suggested in the comments of that script.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Getting the public IP from a fritz.box is a common usecase (at least in Germany). #37 in general complained that container-init deletes execute-rights for scripts in the `/config` folder. However, the root cause is that the `sample-get-ip-from-fritzbox` script  is not distributed in this container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on `Debian 5.6.14-2~bpo10+1 (2020-06-09) x86_64 GNU/Linux` with docker-compose as suggested in documentation and FritzBox 6430.

Added `use=cmd, cmd=/etc/ddclient/get-ip-from-fritzbox` to `/config/ddclient.conf`

`ddclient -daemon=0 -file=/config/ddclient.conf -query` then returns:
````
use=if, if=eth0 address is <my-local-ip>
use=if, if=lo address is 127.0.0.1
WARNING:  cannot connect to ipdetect.dnspark.com:80 socket: IO::Socket::INET: Bad hostname 'ipdetect.dnspark.com'
WARNING:  found neither ipv4 nor ipv6 address
use=web, web=dnspark address is NOT FOUND
use=web, web=dyndns address is <my-public-ip>
use=web, web=loopia address is <my-public-ip>
use=cmd, cmd=/etc/ddclient/get-ip-from-fritzbox address is <my-public-ip>
````

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
#37 