### PR TITLE
Readme: Update docs with secret passing mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ The architectures supported by this image are:
 
 Edit the `ddclient.conf` file found in your `/config` volume (also see official [ddclient documentation](https://ddclient.net)). This config file has many providers to choose from and you basically just have to uncomment your provider and add username/password where requested. If you modify ddclient.conf, ddclient will automaticcaly restart and read the config.
 
+### Passing secrets to ddclient
+To pass secret values such as service passwords to ddclient, add the "_env" suffix to any secret parameter and set it's value to the *name* of the environment variable containing the secret:
+````
+protocol=namecheap,                       \
+server=dynamicdns.park-your-domain.com,   \
+login=my_login_name,                      \
+password_env=DD_PASSWORD \
+@
+````
+
+This example uses the value of the environment variable `$DD_PASSWORD` to set the password parameter.
+
 ### Get dynamic IP from Fritz.Box
 If ddclient shall fetch the dynamic (public) IP-address from a fritz.box (AVM) add the following line to `/config/ddclient.conf`:
 ````

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,6 +38,18 @@ app_setup_block_enabled: true
 app_setup_block: |
   Edit the `ddclient.conf` file found in your `/config` volume (also see official [ddclient documentation](https://ddclient.net)). This config file has many providers to choose from and you basically just have to uncomment your provider and add username/password where requested. If you modify ddclient.conf, ddclient will automaticcaly restart and read the config.
 
+  ### Passing secrets to ddclient
+  To pass secret values such as service passwords to ddclient, add the "_env" suffix to any secret parameter and set it's value to the *name* of the environment variable containing the secret:
+  ````
+  protocol=namecheap,                       \
+  server=dynamicdns.park-your-domain.com,   \
+  login=my_login_name,                      \
+  password_env=DD_PASSWORD \
+  @
+  ````
+
+  This example uses the value of the environment variable `$DD_PASSWORD` to set the password parameter.
+
   ### Get dynamic IP from Fritz.Box
   If ddclient shall fetch the dynamic (public) IP-address from a fritz.box (AVM) add the following line to `/config/ddclient.conf`:
   ````


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-ddclient/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------
## Remaining tasks
- [x] Release ddclient v3.11.0 
- [x] Rebase this pull request once v3.11.0 has been picked up in this repo.

## Description:
This PR adds documentation about the new secret passing mechanism of ddclient to the README.
This feature is available as of prerelease v3.11.0_1 of ddclient.

**Note**: This is marked as draft, the relevant ddclient update has not reached this repo as only a prerelease was made. The relevant release should happen within a few days. (Relevant discussion [here](https://github.com/ddclient/ddclient/issues/552#issuecomment-1763486276))

## Benefits of this PR and context:
The need of a secret passing mechanism has been mentioned before (#44, #68).
I'm guessing that the prior lack of it also led to attempts to bind-mount of the config file (#70).

## How Has This Been Tested?
Local Jenkins run for README.md generation

## Source / References:
The ddclient changelog [here](https://github.com/ddclient/ddclient/blob/d4f9816a6ad86b64caf77af3a15770ca1c1619da/ChangeLog.md#new-features)

The original ddclient pull request for the secret mechanism is [here](https://github.com/ddclient/ddclient/pull/522). This one was rejected due to the recent maintainership transition. It got picked up in the (now merged back) fork [here](https://github.com/rrthomas/ddclient/pull/2).

I did not yet merge the docs update to ddclient.github.io, but the pull request is [here](https://github.com/ddclient/ddclient.github.io/pull/2).
